### PR TITLE
SVN initial import dates

### DIFF
--- a/common/Docs/svn-import-dates.md
+++ b/common/Docs/svn-import-dates.md
@@ -1,0 +1,29 @@
+# DDabLib SVN Import Dates
+
+The following table lists the dates the various sub-projects of the DelphiDabbler Code Library were first placed under version control in a common Subversion repository.
+
+|   Project    |    Date     |
+|--------------|-------------|
+| aboutbox     | 16 Dec 2009 |
+| cbview       | 13 Oct 2010 |
+| consoleapp   | 30 Jun 2010 |
+| dropfiles    | 11 Jan 2010 |
+| envvars      | 19 Feb 2010 |
+| fractions    |     N/a     |
+| hotlabel     | 10 Oct 2010 |
+| ioutils      |     N/a     |
+| md5          |     N/a     |
+| msgdlg       | 09 Aug 2010 |
+| resfile      | 17 Mar 2010 |
+| shellfolders | 25 Jan 2010 |
+| streams      | 02 Oct 2009 |
+| stringpe     | 02 Jan 2010 |
+| sysinfo      | 04 Jul 2009 |
+| verinfo      | 02 Oct 2009 |
+| wdwstate     | 02 Oct 2009 |
+
+
+Sub-projects marked with "N/a" were first created under version control and so were never imported.
+
+All sub-projects that were imported into the Subversion repository have a file named `PreSVNHistory.txt` that details changes that were made before they were placed under version control.
+

--- a/common/Docs/svn-initial-import-dates.md
+++ b/common/Docs/svn-initial-import-dates.md
@@ -1,4 +1,4 @@
-# DDabLib SVN Import Dates
+# DDabLib SVN Initial Import Dates
 
 The following table lists the dates the various sub-projects of the DelphiDabbler Code Library were first placed under version control in a common Subversion repository.
 


### PR DESCRIPTION
Add document describing when each sub-project was first placed under version control.