### PR TITLE
Add holding README.md for each sub-project

### DIFF
--- a/projects/aboutbox/README.md
+++ b/projects/aboutbox/README.md
@@ -1,0 +1,7 @@
+# About Box Component
+
+The source code for this component has moved to the [`ddablib/aboutbox`](https://github.com/ddablib/aboutbox) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/aboutbox/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/cbview/README.md
+++ b/projects/cbview/README.md
@@ -1,0 +1,7 @@
+# Clipboard Viewer Component
+
+The source code for this component has moved to the [`ddablib/cbview`](https://github.com/ddablib/cbview) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/cbview/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/consoleapp/README.md
+++ b/projects/consoleapp/README.md
@@ -1,0 +1,7 @@
+# Console Application Runner Classes
+
+The source code for these classes has moved to the [`ddablib/consoleapp`](https://github.com/ddablib/consoleapp) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/consoleapp/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/dropfiles/README.md
+++ b/projects/dropfiles/README.md
@@ -1,0 +1,7 @@
+# Drop Files Components
+
+The source code for these components has moved to the [`ddablib/dropfiles`](https://github.com/ddablib/dropfiles) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/dropfiles/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/envvars/README.md
+++ b/projects/envvars/README.md
@@ -1,0 +1,7 @@
+# Environment Variables Unit
+
+The source code for this unit has moved to the [`ddablib/envvars`](https://github.com/ddablib/envvars) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/envvars/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/fractions/README.md
+++ b/projects/fractions/README.md
@@ -1,0 +1,7 @@
+# Fractions Unit
+
+The source code for this unit has moved to the [`ddablib/fractions`](https://github.com/ddablib/fractions) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/fractions/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/hotlabel/README.md
+++ b/projects/hotlabel/README.md
@@ -1,0 +1,7 @@
+# Hot Label Component
+
+The source code for this component has moved to the [`ddablib/hotlabel`](https://github.com/ddablib/hotlabel) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/hotlabel/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/ioutils/README.md
+++ b/projects/ioutils/README.md
@@ -1,0 +1,7 @@
+# I/O Utility Classes
+
+The source code for these classes has moved to the [`ddablib/ioutils`](https://github.com/ddablib/ioutils) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/ioutils/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/md5/README.md
+++ b/projects/md5/README.md
@@ -1,0 +1,7 @@
+# MD5 Message Digest Unit
+
+The source code for this unit has moved to the [`ddablib/md5`](https://github.com/ddablib/md5) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/md5/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/msgdlg/README.md
+++ b/projects/msgdlg/README.md
@@ -1,0 +1,7 @@
+# Message Dialogue Components
+
+The source code for these components has moved to the [`ddablib/msgdlg`](https://github.com/ddablib/msgdlg) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/msgdlg/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/resfile/README.md
+++ b/projects/resfile/README.md
@@ -1,0 +1,7 @@
+# Resource File Unit
+
+The source code for this unit has moved to the [`ddablib/resfile`](https://github.com/ddablib/resfile) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/resfile/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/shellfolders/README.md
+++ b/projects/shellfolders/README.md
@@ -1,0 +1,7 @@
+# Shell Folders Unit
+
+The source code for this unit has moved to the [`ddablib/shellfolders`](https://github.com/ddablib/shellfolders) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/shellfolders/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/streams/README.md
+++ b/projects/streams/README.md
@@ -1,0 +1,7 @@
+# Stream Extension Classes
+
+The source code for these classes has moved to the [`ddablib/streams`](https://github.com/ddablib/streams) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/streams/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/stringpe/README.md
+++ b/projects/stringpe/README.md
@@ -1,0 +1,7 @@
+# Extended String Property Editor
+
+The source code for this property editor has moved to the [`ddablib/stringpe`](https://github.com/ddablib/stringpe) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/stringpe/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/sysinfo/README.md
+++ b/projects/sysinfo/README.md
@@ -1,0 +1,7 @@
+# System Information Unit
+
+The source code for this unit has moved to the [`ddablib/sysinfo`](https://github.com/ddablib/sysinfo) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/sysinfo/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/verinfo/README.md
+++ b/projects/verinfo/README.md
@@ -1,0 +1,7 @@
+# Version Information Component
+
+The source code for this component has moved to the [`ddablib/verinfo`](https://github.com/ddablib/verinfo) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/verinfo/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.

--- a/projects/wdwstate/README.md
+++ b/projects/wdwstate/README.md
@@ -1,0 +1,7 @@
+# Window State Components
+
+The source code for these components has moved to the [`ddablib/wdwstate`](https://github.com/ddablib/wdwstate) project. All further development is taking place there.
+
+Any bugs & feature requests should be reported on the project's own [Issues](https://github.com/ddablib/wdwstate/issues) page. ***Do not report them here.***
+
+> ⚠️ **WARNING:** Source code and the issues page may be removed from this repository at any time.


### PR DESCRIPTION
Such files should note that the sub-project has moved to `ddablib` and warn that code may be removed from this project.